### PR TITLE
add unit test and delete functionality

### DIFF
--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -29,3 +29,10 @@ exports.updateTodo = async (req, res) => {
   );
   res.json(updatedTodo);
 };
+
+// delete an existing todo
+exports.deleteTodo = async (req, res) => {
+  const { id } = req.params;
+  await Todo.findByIdAndDelete(id);
+  res.json({ message: "Todo deleted successfully" });
+};

--- a/frontend/src/components/AddTodo.test.js
+++ b/frontend/src/components/AddTodo.test.js
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import AddTodo from "./AddTodo";
+
+// frontend/src/components/AddTodo.test.js
+
+test("renders AddTodo form", () => {
+  render(<AddTodo onAdd={jest.fn()} />);
+  expect(screen.getByPlaceholderText(/Title/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/Description/i)).toBeInTheDocument();
+  expect(screen.getByText(/Add Todo/i)).toBeInTheDocument();
+});
+
+test("calls onAdd with correct data when form is submitted", () => {
+  const onAddMock = jest.fn();
+  render(<AddTodo onAdd={onAddMock} />);
+
+  fireEvent.change(screen.getByPlaceholderText(/Title/i), {
+    target: { value: "Test Title" },
+  });
+  fireEvent.change(screen.getByPlaceholderText(/Description/i), {
+    target: { value: "Test Description" },
+  });
+  fireEvent.click(screen.getByText(/Add Todo/i));
+
+  expect(onAddMock).toHaveBeenCalledWith({
+    title: "Test Title",
+    description: "Test Description",
+  });
+  expect(screen.getByPlaceholderText(/Title/i).value).toBe("");
+  expect(screen.getByPlaceholderText(/Description/i).value).toBe("");
+});


### PR DESCRIPTION
This pull request introduces a new feature for deleting todos and adds unit tests for the `AddTodo` component. The most important changes include the addition of a `deleteTodo` function in the backend and the creation of tests for the `AddTodo` form in the frontend.

### Backend Changes:
* Added a `deleteTodo` function to handle the deletion of todos by ID in `todoController.js`. (`backend/controllers/todoController.js`)

### Frontend Changes:
* Added unit tests for the `AddTodo` component to verify that the form renders correctly and that the `onAdd` callback is called with the correct data when the form is submitted. (`frontend/src/components/AddTodo.test.js`)