### PR TITLE
add unit test and delete functionality

### DIFF
--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -29,3 +29,10 @@ exports.updateTodo = async (req, res) => {
   );
   res.json(updatedTodo);
 };
+
+// Delete a todo
+exports.deleteTodo = async (req, res) => {
+  const { id } = req.params;
+  await Todo.findByIdAndDelete(id);
+  res.json({ message: "Todo deleted successfully" });
+};

--- a/frontend/src/components/AddTodo.test.js
+++ b/frontend/src/components/AddTodo.test.js
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import AddTodo from "./AddTodo";
+
+// frontend/src/components/AddTodo.test.js
+
+test("renders AddTodo form", () => {
+  render(<AddTodo onAdd={() => {}} />);
+  expect(screen.getByPlaceholderText(/Title/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/Description/i)).toBeInTheDocument();
+  expect(screen.getByText(/Add Todo/i)).toBeInTheDocument();
+});
+
+test("calls onAdd with correct data when form is submitted", () => {
+  const mockOnAdd = jest.fn();
+  render(<AddTodo onAdd={mockOnAdd} />);
+
+  fireEvent.change(screen.getByPlaceholderText(/Title/i), {
+    target: { value: "Test Title" },
+  });
+  fireEvent.change(screen.getByPlaceholderText(/Description/i), {
+    target: { value: "Test Description" },
+  });
+  fireEvent.click(screen.getByText(/Add Todo/i));
+
+  expect(mockOnAdd).toHaveBeenCalledWith({
+    title: "Test Title",
+    description: "Test Description",
+  });
+});
+
+test("clears input fields after form submission", () => {
+  render(<AddTodo onAdd={() => {}} />);
+
+  const titleInput = screen.getByPlaceholderText(/Title/i);
+  const descriptionInput = screen.getByPlaceholderText(/Description/i);
+
+  fireEvent.change(titleInput, { target: { value: "Test Title" } });
+  fireEvent.change(descriptionInput, { target: { value: "Test Description" } });
+  fireEvent.click(screen.getByText(/Add Todo/i));
+
+  expect(titleInput.value).toBe("");
+  expect(descriptionInput.value).toBe("");
+});


### PR DESCRIPTION
This pull request introduces a new feature for deleting todos and adds unit tests for the `AddTodo` component. The most important changes include the addition of a new controller method for deleting todos and comprehensive tests for the `AddTodo` component.

### Backend Changes:
* Added `deleteTodo` method to `todoController.js` to handle the deletion of todos by ID. (`backend/controllers/todoController.js`)

### Frontend Changes:
* Created unit tests for the `AddTodo` component to verify the form rendering, submission behavior, and input field reset functionality. (`frontend/src/components/AddTodo.test.js`)